### PR TITLE
Add a remove-word command

### DIFF
--- a/jit-spell.el
+++ b/jit-spell.el
@@ -566,11 +566,11 @@ Interactively offer the current word or sub-words."
             (mapc (pcase-lambda (`(,buf _ _ _))
                     (with-current-buffer buf (jit-lock-refontify)))
                   pending)))))
-    (message "\"%s\" removed from %s." word (string-join places " and "))
     (if (not places)
         (message
          "\"%s\" not found in the personal dictionary or local word lists."
          word)
+      (message "\"%s\" removed from %s." word (string-join places " and "))
       (jit-lock-refontify))))
 
 (defalias 'jit-spell-change-dictionary 'ispell-change-dictionary) ;For discoverability


### PR DESCRIPTION
Fix #11 

It took me some time due to copyright assignment and then a busy period but here is a version of the command that I think should work.

Some things to consider:

1) Right now it offers the current word and sub words as candidates. I think a better alternative would be to offer recent addition as candidates but they are not currently recorded but that is not too hard to change. 

2) Right now the command requires confirmation to select a candidate which I think is good since the syntax tables idea of current word might not agree with the spell-checker and this allows the user to modify the word to be removed. But maybe using prefix arg to directly use current word should be possible.

3)  When a word from personal dictionary is removed this basically issues a `jit-lock-refontify` in the buffer for every pending request. For the most likely scenario which at least for me is to correct a recent mistakenly added word this is overkill. Just starting a new process and copying the pending requests should be enough for that case. On the other hand if the word being removed is used in other buffers which have no pending request this would highlight those misspellings until recertification is done by some other means. If that scenario is a concern then the better way is go through the buffer list and issue `jit-lock-refontify` for every buffer which the process we are killing was being used. I am willing to go in either of those directions.

Thanks for the great package.