### PR TITLE
Widen before making overlays

### DIFF
--- a/jit-spell.el
+++ b/jit-spell.el
@@ -162,14 +162,15 @@ Also add the list of CORRECTIONS as a property."
 MISSPELLINGS is a list with elements consisting of a word, a
 character offset from START, and a list of corrections."
   (with-current-buffer buffer
-    (with-silent-modifications
-      (remove-list-of-text-properties start end '(jit-spell-pending))
-      (jit-spell--remove-overlays start end)
-      (pcase-dolist (`(,word ,offset ,corrections) misspellings)
-        (let* ((wstart (+ start offset -1))
-               (wend (+ wstart (length word))))
-          (unless (funcall jit-spell--ignored-p wstart wend)
-            (jit-spell--make-overlay wstart wend corrections)))))))
+    (without-restriction
+      (with-silent-modifications
+        (remove-list-of-text-properties start end '(jit-spell-pending))
+        (jit-spell--remove-overlays start end)
+        (pcase-dolist (`(,word ,offset ,corrections) misspellings)
+          (let* ((wstart (+ start offset -1))
+                 (wend (+ wstart (length word))))
+            (unless (funcall jit-spell--ignored-p wstart wend)
+              (jit-spell--make-overlay wstart wend corrections))))))))
 
 (defun jit-spell--overlay-at (pos)
   "Return the jit-spell overlay at POS, if it exists."


### PR DESCRIPTION
Narrowing might happen in the window between the request is queued and time filter function runs. When this happens jit-spell--make-overlays will fail with args out of bounds error and jit-spell stops working afterwards.